### PR TITLE
Return sampled data in read requests when Hints.StepMs is present

### DIFF
--- a/internal/clickhouse/conn.go
+++ b/internal/clickhouse/conn.go
@@ -17,13 +17,18 @@ type ClickHouseAdapter struct {
 	// NOTE: We switched to sql.DB, but clickhouse.Conn appears to handle
 	// PrepareBatch and Query correctly with multiple goroutines, despite
 	// technically being a "driver.Conn"
-	db                     *sql.DB
-	table                  string
-	readRequestIgnoreLabel string
+	db                        *sql.DB
+	table                     string
+	readRequestIgnoreLabel    string
+	readRequestIgnoreStepHint bool
 }
 
 func (ch *ClickHouseAdapter) IgnoreLabelInReadRequests(label string) {
 	ch.readRequestIgnoreLabel = label
+}
+
+func (ch *ClickHouseAdapter) IgnoreStepInReadRequests(ignore bool) {
+	ch.readRequestIgnoreStepHint = ignore
 }
 
 func NewClickHouseAdapter(address, database, username, password, table string) (*ClickHouseAdapter, error) {

--- a/internal/clickhouse/read.go
+++ b/internal/clickhouse/read.go
@@ -20,11 +20,9 @@ func (ch *ClickHouseAdapter) ReadRequest(ctx context.Context, req *prompb.ReadRe
 
 		sb := &sqlBuilder{}
 
-		sb.Clause("updated_at >= fromUnixTimestamp64Milli(?)", q.StartTimestampMs)
 		sb.Clause("t >= fromUnixTimestamp64Milli(?)", q.StartTimestampMs)
 
 		if q.EndTimestampMs > 0 {
-			sb.Clause("updated_at <= fromUnixTimestamp64Milli(?)", q.EndTimestampMs)
 			sb.Clause("t <= fromUnixTimestamp64Milli(?)", q.EndTimestampMs)
 		}
 

--- a/internal/clickhouse/read.go
+++ b/internal/clickhouse/read.go
@@ -21,16 +21,29 @@ func (ch *ClickHouseAdapter) ReadRequest(ctx context.Context, req *prompb.ReadRe
 		sb := &sqlBuilder{}
 
 		sb.Clause("updated_at >= fromUnixTimestamp64Milli(?)", q.StartTimestampMs)
+		sb.Clause("t >= fromUnixTimestamp64Milli(?)", q.StartTimestampMs)
 
 		if q.EndTimestampMs > 0 {
 			sb.Clause("updated_at <= fromUnixTimestamp64Milli(?)", q.EndTimestampMs)
+			sb.Clause("t <= fromUnixTimestamp64Milli(?)", q.EndTimestampMs)
 		}
 
 		if err := addMatcherClauses(q.Matchers, sb, ch.readRequestIgnoreLabel); err != nil {
 			return nil, err
 		}
 
-		rows, err := ch.db.QueryContext(ctx, "SELECT metric_name, arraySort(labels) as slb, updated_at, value FROM "+ch.table+" WHERE "+sb.Where()+" ORDER BY metric_name, slb, updated_at", sb.Args()...)
+		timeField := "updated_at"
+
+		// When plotting graphs, Prometheus or Grafana may suggest returning
+		// a data point for every "StepMs" instead of all data points.
+		//
+		// The hint seems optimistic, so return twice as many as they asked for.
+		if q.Hints.StepMs > 2000 && ch.readRequestIgnoreStepHint == false {
+			// use 'second' as 'millisecond' does not work with DateTime fields
+			timeField = fmt.Sprintf("toStartOfInterval(updated_at, INTERVAL %d second)", q.Hints.StepMs/2000)
+		}
+
+		rows, err := ch.db.QueryContext(ctx, "SELECT metric_name, arraySort(labels) as slb, "+timeField+" AS t, max(value) as max_0 FROM "+ch.table+" WHERE "+sb.Where()+" GROUP BY metric_name, slb, t ORDER BY metric_name, slb, t", sb.Args()...)
 		if err != nil {
 			return nil, err
 		}

--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func main() {
 	var httpAddr string
 	var clickAddr, database, username, password, table string
 	var readRequestIgnoreLabel string
+	var readRequestIgnoreStepHint bool
 	flag.StringVar(&httpAddr, "http", "9131", "listen on this [address:]port")
 	flag.StringVar(&clickAddr, "db", "127.0.0.1:9000", "ClickHouse DB at this address:port")
 	flag.StringVar(&database, "db.database", "default", "ClickHouse database")
@@ -84,6 +85,7 @@ func main() {
 	flag.StringVar(&password, "db.password", "", "ClickHouse password")
 	flag.StringVar(&table, "table", "metrics.samples", "write to this database.tablename")
 	flag.StringVar(&readRequestIgnoreLabel, "read.ignore-label", "remote=clickhouse", "ignore this label in read requests")
+	flag.BoolVar(&readRequestIgnoreStepHint, "read.ignore-step", false, "ignore step hint in read requests")
 	flag.Parse()
 
 	if !strings.Contains(httpAddr, ":") {
@@ -103,6 +105,8 @@ func main() {
 	if readRequestIgnoreLabel != "" {
 		ch.IgnoreLabelInReadRequests(readRequestIgnoreLabel)
 	}
+
+	ch.IgnoreStepInReadRequests(readRequestIgnoreStepHint)
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)


### PR DESCRIPTION
When plotting graphs, Prometheus or Grafana may suggest returning a data point for every `StepMs` instead of all data points.

This hint significantly speeds up drawing graphs, as only a fraction of the timeseries data actually needs to be sent.

If you don't want this optimization, use `-read.ignore-step` to ignore Hints.StepMs

NOTE: With StepMs hinting the Prometheus "query_range" endpoint sometimes returns no data points, even though it asked us for data and we supplied it.