### PR TITLE
feat: docker images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,46 @@
+name: Build and publish docker image
+
+on:
+  push:
+    branches: [ 'main' ]
+
+jobs:
+  build-push-docker-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - run: go install github.com/mitchellh/gox@latest # setup gox
+      - run: make gox-linux
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          platforms: linux/arm64,linux/amd64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.18.0
+ARG TARGETOS
+ARG TARGETARCH
+COPY build/remote-tsdb-clickhouse_${TARGETOS}_${TARGETARCH} /usr/local/bin/remote-tsdb-clickhouse
+RUN chmod +x /usr/local/bin/remote-tsdb-clickhouse

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+all: build-linux-amd64 build-linux-arm64
+
+build-linux-amd64:
+	mkdir -p build
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/remote-tsdb-clickhouse_linux_amd64 main.go
+
+build-linux-arm64:
+	mkdir -p build
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o build/remote-tsdb-clickhouse_linux_arm64 main.go
+
+gox-linux:
+	gox -osarch="linux/amd64 linux/arm64" -output="build/remote-tsdb-clickhouse_{{.OS}}_{{.Arch}}"
+
+gox-all:
+	gox -osarch="linux/amd64 linux/arm64" -output="build/remote-tsdb-clickhouse_{{.OS}}_{{.Arch}}"
+
+clean:
+	rm -f build/remote-tsdb-clickhouse_*


### PR DESCRIPTION
Thanks for this neat project! I've been wanting something like it for a while, and it seems easy enough to use and possibly hack on if needed.

I wanted to deploy this as a container (arm64!), and there weren't binaries. I don't really know Go that well, so I basically cobbled together this code from https://github.com/LeslieLeung/go-multiplatform-docker and tested it in my own repository fork. The image seems to work and I'm running it on an Ampere Oracle Cloud instance.

This will create a new tag on ghcr.io/jamessanford/remote-tsdb-clickhouse, and there will be a tag for every commit and the continuously-updated `main` reference.