### PR TITLE
Note about increasing max_samples_per_send

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,13 @@ In your `prometheus.yaml`:
 ```
 remote_write:
  - url: "http://localhost:9131/write"
+   queue_config:
+     max_samples_per_send: 10000
 ```
+
+ClickHouse prefers fewer writes with more samples per write.  Above a certain
+rate you may need to adjust Prometheus `capacity` and
+`max_samples_per_send` as per [Prometheus Remote Write Tuning](https://prometheus.io/docs/practices/remote_write/) if you see "Too many parts" errors or `prometheus_remote_storage_samples_pending` keeps growing.
 
 ### Configure Prometheus remote reader
 


### PR DESCRIPTION
As found in issue #11, tuning may be needed for remote writes, to allow larger batches of metrics to be sent to ClickHouse in fewer writes.

I picked 10000 as a "safe for everyone" value that matches the current Prometheus per-shard capacity default, but allows the entire queue to be sent with one write.